### PR TITLE
Add support for whitelabel AnywAIR and update versions from sniffer logs

### DIFF
--- a/pyintesishome/pyintesishome.py
+++ b/pyintesishome/pyintesishome.py
@@ -15,6 +15,7 @@ INTESIS_NULL = 32768
 
 DEVICE_INTESISHOME = "IntesisHome"
 DEVICE_AIRCONWITHME = "airconwithme"
+DEVICE_ANYWAIR = "anywair"
 
 API_DISCONNECTED = "Disconnected"
 API_CONNECTING = "Connecting"
@@ -321,10 +322,15 @@ ERROR_MAP = {
 
 API_URL = {
     DEVICE_AIRCONWITHME: "https://user.airconwithme.com/api.php/get/control",
+    DEVICE_ANYWAIR: "https://anywair.intesishome.com/api.php/get/control",
     DEVICE_INTESISHOME: "https://user.intesishome.com/api.php/get/control",
 }
 
-API_VER = {DEVICE_AIRCONWITHME: "1.6.2", DEVICE_INTESISHOME: "1.8.5"}
+API_VER = {
+    DEVICE_AIRCONWITHME: "1.6.2",
+    DEVICE_ANYWAIR: "2.9",
+    DEVICE_INTESISHOME: "1.2.2"
+}
 
 
 class IHConnectionError(Exception):


### PR DESCRIPTION
AnywAIR is the whitelabel version of IntesisHome for Fujitsu - https://www.fujitsugeneral.com.au/anywair

I've added support for this and sniffed the app versions for anywair and IntesisHome and updated these for the latest ones being sent to the APIs.

Once this is approved I'll open a PR for HomeAssistant.