### PR TITLE
[Intesishome_Local] Add 192 Key to INTESIS_MAP

### DIFF
--- a/pyintesishome/const.py
+++ b/pyintesishome/const.py
@@ -202,6 +202,7 @@ INTESIS_MAP = {
     185: {"name": "uid_185"},
     186: {"name": "uid_186"},
     191: {"name": "uid_binary_input_sleep_mode"},
+    192: {"name": "error_address"},
     50000: {
         "name": "external_led",
         "values": {0: "off", 1: "on", 2: "blinking only on change"},


### PR DESCRIPTION
On device model "FJ-RC-WIFI-1B" there is a 192 key returned by the "getavailabledatapoints" cmd, that is not mapped actually and give error on initialization