### PR TITLE
Fix: Added auto mode to fan speed map for config 30

### DIFF
--- a/pyintesishome/const.py
+++ b/pyintesishome/const.py
@@ -120,7 +120,7 @@ INTESIS_MAP = {
             7: {0: "auto", 1: "low", 2: "high"},
             14: {1: "low", 2: "medium", 3: "high"},
             15: {0: "auto", 1: "low", 2: "medium", 3: "high"},
-            30: {1: "quiet", 2: "low", 3: "medium", 4: "high"},
+            30: {0: "auto", 1: "quiet", 2: "low", 3: "medium", 4: "high"},
             31: {0: "auto", 1: "quiet", 2: "low", 3: "medium", 4: "high"},
             62: {1: "quiet", 2: "low", 3: "medium", 4: "high", 5: "max"},
             63: {0: "auto", 1: "quiet", 2: "low", 3: "medium", 4: "high", 5: "max"},


### PR DESCRIPTION
My Mitsubishi Heavy Industries Airconditioner with airconwithme WiFi controler an auto fan speed mode.
However pyIntesishome maps only this for my device:
`30: {1: "quiet", 2: "low", 3: "medium", 4: "high"},`

So I changed that to:
`30: {0: "auto", 1: "quiet", 2: "low", 3: "medium", 4: "high"},`

Here's the full json output for both my devices, both support fan speed auto, 2nd auto is currently set to auto (fan speed 0):
```
{
    "redacted_id1": {
        "name": "Airco Huiskamer",
        "widgets": [
            15,
            3,
            5,
            7,
            17,
            9,
            13
        ],
        "model": 550,
        "power": "off",
        "mode": "cool",
        "fan_speed": 3,
        "vvane": "manual2",
        "setpoint": 180,
        "temperature": 260,
        "remote_controller_lock": 0,
        "working_hours": 2660,
        "alarm_status": 0,
        "error_code": 0,
        "quiet_mode": "off",
        "setpoint_min": 180,
        "setpoint_max": 300,
        "outdoor_temp": 270,
        "error_reset": 0,
        "config_mode_map": 63,
        "runtime_mode_restrictions": 0,
        "config_horizontal_vanes": 0,
        "config_vertical_vanes": 1054,
        "config_quiet": 0,
        "config_confirm_off": 0,
        "config_fan_map": {
            "1": "quiet",
            "2": "low",
            "3": "medium",
            "4": "high"
        },
        "unknown_uid_193": 0,
        "external_led": "on",
        "internal_led": "off",
        "internal_temperature_offset": 0,
        "temp_limitation": "off",
        "cool_temperature_min": 240,
        "cool_temperature_max": 280,
        "heat_temperature_min": 230,
        "unknown_uid_50008": 1,
        "unknown_uid_50009": 3,
        "unknown_uid_50010": 255,
        "unknown_uid_50100": 0,
        "rssi": 192
    },
    "redacted_id2": {
        "name": "Airco Slaapkamer",
        "widgets": [
            15,
            3,
            5,
            7,
            17,
            9,
            13
        ],
        "model": 550,
        "power": "off",
        "mode": "cool",
        "fan_speed": 0,
        "vvane": "manual1",
        "setpoint": 230,
        "temperature": 240,
        "remote_controller_lock": 0,
        "working_hours": 3934,
        "alarm_status": 0,
        "error_code": 0,
        "quiet_mode": "off",
        "setpoint_min": 180,
        "setpoint_max": 300,
        "outdoor_temp": 280,
        "error_reset": 0,
        "config_mode_map": 63,
        "runtime_mode_restrictions": 0,
        "config_horizontal_vanes": 0,
        "config_vertical_vanes": 1054,
        "config_quiet": 0,
        "config_confirm_off": 0,
        "config_fan_map": {
            "1": "quiet",
            "2": "low",
            "3": "medium",
            "4": "high"
        },
        "unknown_uid_193": 0,
        "external_led": "on",
        "internal_led": "off",
        "internal_temperature_offset": 0,
        "temp_limitation": "off",
        "cool_temperature_min": 240,
        "cool_temperature_max": 280,
        "heat_temperature_min": 230,
        "unknown_uid_50008": 1,
        "unknown_uid_50009": 3,
        "unknown_uid_50010": 255,
        "unknown_uid_50100": 0,
        "rssi": 200
    }
}```

I think this is the cause for this issue with Home Assistant: https://github.com/home-assistant/core/issues/125340