### PR TITLE
fix: timeout of command connect_req when login to INTESISHOME (issues #55 and #57)

### DIFF
--- a/pyintesishome/intesishome.py
+++ b/pyintesishome/intesishome.py
@@ -120,10 +120,10 @@ class IntesisHome(IntesisBase):
                 auth_msg = '{"command":"connect_req","data":{"token":%s}}' % (
                     self._auth_token
                 )
+                self._receive_task = self._event_loop.create_task(self._data_received())
                 await self._send_command(auth_msg)
                 # Clear the OTP
                 self._auth_token = None
-                self._receive_task = self._event_loop.create_task(self._data_received())
                 self._keepalive_task = self._event_loop.create_task(
                     self._send_keepalive()
                 )


### PR DESCRIPTION
When it tries to connect to the tcp server of intesishome using command connect_req always ending stop the connection.

This PR fix the issue https://github.com/jnimmo/pyIntesisHome/issues/55