### PR TITLE
fix: set connected to False after login in tcp server

### DIFF
--- a/pyintesishome/intesishome.py
+++ b/pyintesishome/intesishome.py
@@ -138,7 +138,7 @@ class IntesisHome(IntesisBase):
                     self._cmd_server_port,
                     exc,
                 )
-            self._connected = False
+                self._connected = False
             self._connecting = False
 
     async def poll_status(self, sendcallback=False):


### PR DESCRIPTION
This PR solved disconnection issues in HA integration. After the first updated of the controller the HA entitiy changed to unavailable.