### PR TITLE
fix: guard against None mode_map in get_mode_list

### DIFF
--- a/pyintesishome/intesisbase.py
+++ b/pyintesishome/intesisbase.py
@@ -311,7 +311,7 @@ class IntesisBase:
 
         # Generate the mode list from the map
         for mode_bit in mode_bits:
-            if mode_map & mode_bit:
+            if mode_map is not None and mode_map & mode_bit:
                 mode_list.append(mode_bits.get(mode_bit))
 
         return mode_list


### PR DESCRIPTION
## Summary

- Adds a `None` check before the bitwise `&` in `get_mode_list` so devices that don't return `config_mode_map` or `config_operating_mode` in their API response don't crash on setup.
- Every other capability check in `IntesisBase` already guards for `None`; this was the one place that was missed.

## Root cause

`get_device_property` returns `None` when a key is absent. The loop then hit `if mode_map & mode_bit:` which raises:
```
TypeError: unsupported operand type(s) for &: 'NoneType' and 'int'
```

## Fix

```python
# Before
if mode_map & mode_bit:
# After
if mode_map is not None and mode_map & mode_bit:
```

## References

Fixes home-assistant/core#167474

🤖 Generated with [Claude Code](https://claude.com/claude-code)