### PR TITLE
fix: use relative import in intesisbox.py to prevent system package conflict

### DIFF
--- a/pyintesishome/intesisbox.py
+++ b/pyintesishome/intesisbox.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import List
 
-from pyintesishome.intesisbase import IntesisBase
+from .intesisbase import IntesisBase
 
 from .const import (
     DEVICE_INTESISBOX,


### PR DESCRIPTION
intesisbox.py used an absolute import (`from pyintesishome.intesisbase import IntesisBase`) which breaks when pyintesishome is vendored inside another package, causing the system-installed package to be loaded instead of the vendored copy. All other files in the package use relative imports — this change makes intesisbox.py consistent with the rest of the package.

No impact on non-vendored use since relative imports within a package resolve correctly regardless of how the package is installed.