### PR TITLE
fix: inject AUTO fan mode for MH-AC-WIFI-1 devices in _get_fan_map

### DIFF
--- a/pyintesishome/intesishomelocal.py
+++ b/pyintesishome/intesishomelocal.py
@@ -303,7 +303,12 @@ class IntesisHomeLocal(IntesisBase):
         if 4 not in self._datapoints:
             return None
         fan_values = sorted(self._datapoints[4]["descr"]["states"])
-        for values in INTESIS_MAP[67]["values"].values():
+        # MH-AC-WIFI-1 supports AUTO fan (uid 4 value 0) even when not
+        # advertised in the datapoints descriptor
+        device_model = self._info.get("deviceModel", "") if self._info else ""
+        if 0 not in fan_values and "MH-AC-WIFI" in device_model:
+            fan_values = [0] + fan_values
+        for map_key, values in INTESIS_MAP[67]["values"].items():
             if sorted(values.keys()) == fan_values:
                 return values
         return INTESIS_MAP[67]["values"][63]


### PR DESCRIPTION
Fixes #69

MH-AC-WIFI-1 adapters report fan speed states `[1,2,3,4]` in their datapoints descriptor, omitting state `0` (auto). No entry in `INTESIS_MAP[67]` exactly matches `[1,2,3,4]`, so `_get_fan_map()` falls back to key 63 which incorrectly exposes "max" (5) as a fan option in HA — not advertised by the device and may not be supported depending on the connected MHI unit.

The device genuinely supports AUTO fan (uid 4, value 0) even though it is not advertised in the datapoints descriptor. This fix injects state `0` for MH-AC-WIFI devices before the map lookup, correctly matching key 30 `{0: auto, 1: quiet, 2: low, 3: medium, 4: high}` and removing the spurious max option.

Tested on MH-AC-WIFI-1 hardware with Mitsubishi Heavy Industries SRK series units (3 devices).