### PR TITLE
fix: guard get_horizontal_swing_list() against missing UID 6

### DIFF
--- a/pyintesishome/intesishomelocal.py
+++ b/pyintesishome/intesishomelocal.py
@@ -322,12 +322,13 @@ class IntesisHomeLocal(IntesisBase):
 
     def get_horizontal_swing_list(self, device_id) -> list:
         """Get possible entity modes."""
+        if not self._has_datapoint("hvane"):
+            return []
         uid = COMMAND_MAP["hvane"]["uid"]
         return [
             INTESIS_MAP[uid]["values"][i]
             for i in self._datapoints[uid]["descr"]["states"]
         ]
-
     def has_horizontal_swing(self, device_id) -> bool:
         """Entity supports horizontal swing."""
         return self._has_datapoint("hvane")


### PR DESCRIPTION
## Summary

Adds a missing guard in `get_horizontal_swing_list()` in `intesishomelocal.py` to handle devices that do not expose UID 6 (horizontal vane).

## Problem

Introduced in #58. On devices such as MH-AC-WIFI-1 (confirmed on firmware 1.3.1 and 1.4.7), UID 6 is not present in `getavailabledatapoints`. Calling `get_horizontal_swing_list()` on these devices raises a `KeyError` because `self._datapoints[uid]` is accessed without checking if the key exists.

Fixes #72.

## Change

`get_horizontal_swing_list()` now returns an empty list early if `_has_datapoint("hvane")` is false, consistent with the guard already used in `has_horizontal_swing()` immediately below it.

## Testing

Tested on three MH-AC-WIFI-1 adapters (firmware 1.3.1) — entities load correctly, no horizontal swing exposed (correct), no `KeyError`.