### PR TITLE
fix: opt into Node 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   DEFAULT_PYTHON: "3.14"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   ruff:


### PR DESCRIPTION
Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to the workflow `env:` block to opt into Node 24 ahead of the forced migration.

GitHub runners will default to Node 24 from June 2nd, 2026 and Node 20 will be fully removed later in 2026.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/