### PR TITLE
fix: resolve ruff isort and pylint unused variable CI failures

### DIFF
--- a/pyintesishome/intesisbox.py
+++ b/pyintesishome/intesisbox.py
@@ -4,8 +4,6 @@ import asyncio
 import logging
 from typing import List
 
-from .intesisbase import IntesisBase
-
 from .const import (
     DEVICE_INTESISBOX,
     INTESIS_NULL,
@@ -21,6 +19,7 @@ from .const import (
     INTESISBOX_MODE_MAP,
 )
 from .helpers import uint32
+from .intesisbase import IntesisBase
 
 _LOGGER = logging.getLogger("pyintesishome")
 

--- a/pyintesishome/intesishomelocal.py
+++ b/pyintesishome/intesishomelocal.py
@@ -334,6 +334,7 @@ class IntesisHomeLocal(IntesisBase):
             INTESIS_MAP[uid]["values"][i]
             for i in self._datapoints[uid]["descr"]["states"]
         ]
+
     def has_horizontal_swing(self, device_id) -> bool:
         """Entity supports horizontal swing."""
         return self._has_datapoint("hvane")

--- a/pyintesishome/intesishomelocal.py
+++ b/pyintesishome/intesishomelocal.py
@@ -308,7 +308,7 @@ class IntesisHomeLocal(IntesisBase):
         device_model = self._info.get("deviceModel", "") if self._info else ""
         if 0 not in fan_values and "MH-AC-WIFI" in device_model:
             fan_values = [0] + fan_values
-        for map_key, values in INTESIS_MAP[67]["values"].items():
+        for values in INTESIS_MAP[67]["values"].values():
             if sorted(values.keys()) == fan_values:
                 return values
         return INTESIS_MAP[67]["values"][63]


### PR DESCRIPTION
Fixes two CI failures introduced by PR #70 and PR #71:

**ruff I001 — `intesisbox.py`**
Relative imports were not grouped correctly after the import reordering in #70. Fixed by grouping all relative imports together in alphabetical order.

**pylint W0612 — `intesishomelocal.py`**
`map_key` was unpacked in the for loop but never used, introduced in #71. Fixed by iterating over `.values()` directly instead of `.items()`.

All 59 existing tests pass.