### PR TITLE
fix: correct _set_value return value for IntesisHomeLocal

### DIFF
--- a/pyintesishome/intesishomelocal.py
+++ b/pyintesishome/intesishomelocal.py
@@ -169,7 +169,7 @@ class IntesisHomeLocal(IntesisBase):
             # If there's neither a "success" or "error" key, something is very
             # wonky, so log an error plus the entire response.
             if json_response.get("success", False):
-                return json_response.get("data")
+                return json_response.get("data") or {}
             if "error" in json_response:
                 error = json_response["error"]
                 if error.get("code") in [1, 5]:

--- a/pyintesishome/intesishomelocal.py
+++ b/pyintesishome/intesishomelocal.py
@@ -205,11 +205,12 @@ class IntesisHomeLocal(IntesisBase):
         return response["dpval"]["value"]
 
     async def _set_value(self, device_id, uid, value):
-        return await self._request(
+        result = await self._request(
             LOCAL_CMD_SET_DP_VALUE,
             uid=uid,
             value=value,
         )
+        return result is not None
 
     async def get_datapoints(self) -> dict:
         """Get all available datapoints."""
@@ -334,6 +335,7 @@ class IntesisHomeLocal(IntesisBase):
             INTESIS_MAP[uid]["values"][i]
             for i in self._datapoints[uid]["descr"]["states"]
         ]
+
     def has_horizontal_swing(self, device_id) -> bool:
         """Entity supports horizontal swing."""
         return self._has_datapoint("hvane")


### PR DESCRIPTION
## Problem

`IntesisHomeLocal._set_value()` was returning `None` on success, causing all set commands (power, mode, fan speed, temperature, etc.) to incorrectly signal failure to callers.

The root cause is two-fold:

1. The device responds to successful SET commands with `{'success': True, 'data': None}` — `_request()` was returning `json_response.get("data")` which evaluates to `None`
2. `_set_value()` was passing the raw response through, so callers doing `bool(await self._set_value(...))` always received `False` even on success

## Fix

- `_request()` now returns `{}` instead of `None` when a successful response has no data payload, preserving the semantic that `None` means failure
- `_set_value()` now returns `result is not None` — explicitly `True` on success, `False` on failure

## Impact

- Fixes all local HTTP set commands for `IntesisHomeLocal` devices
- No impact on cloud (`IntesisHome`) or IntesisBox — both have separate `_set_value` implementations
- All 59 existing tests pass

## Context

This bug was discovered while testing dolkensp's `hass-intesishome` ([jnimmo/hass-intesishome:PR #41](https://github.com/jnimmo/hass-intesishome/pull/41)) which introduced `_expect_ack()` to surface failed set commands as HA errors — the correct behaviour that exposed this pre-existing bug.