### PR TITLE
Fix KeyError in get_device_property when device_id is not in _devices

### DIFF
--- a/pyintesishome/intesisbase.py
+++ b/pyintesishome/intesisbase.py
@@ -254,7 +254,10 @@ class IntesisBase:
 
     def get_device_property(self, device_id, property_name):
         """Public method to get a property of the specified device"""
-        return self._devices[str(device_id)].get(property_name)
+        device = self._devices.get(str(device_id))
+        if device is None:
+            return None
+        return device.get(property_name)
 
     def get_run_hours(self, device_id) -> str:
         """Public method returns the run hours of the IntesisHome controller."""


### PR DESCRIPTION
When the devices dictionary does not yet contain the requested device_id 
(e.g. during startup or reconnect), a direct dictionary lookup raises a 
KeyError. Using .get() with a None fallback makes the lookup safe.

Fixes: https://github.com/home-assistant/core/issues/171209
Related: https://github.com/jnimmo/pyIntesisHome/issues/64